### PR TITLE
Make tests compatible with hydrator 3

### DIFF
--- a/test/TableGatewayAbstractFactoryTest.php
+++ b/test/TableGatewayAbstractFactoryTest.php
@@ -18,7 +18,6 @@ use Laminas\Db\TableGateway\TableGateway;
 use Laminas\Hydrator\ClassMethods;
 use Laminas\Hydrator\ClassMethodsHydrator;
 use Laminas\Hydrator\HydratorPluginManager;
-use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
 class TableGatewayAbstractFactoryTest extends TestCase

--- a/test/TableGatewayAbstractFactoryTest.php
+++ b/test/TableGatewayAbstractFactoryTest.php
@@ -18,6 +18,7 @@ use Laminas\Db\TableGateway\TableGateway;
 use Laminas\Hydrator\ClassMethods;
 use Laminas\Hydrator\ClassMethodsHydrator;
 use Laminas\Hydrator\HydratorPluginManager;
+use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
 class TableGatewayAbstractFactoryTest extends TestCase
@@ -150,11 +151,7 @@ class TableGatewayAbstractFactoryTest extends TestCase
      */
     public function testFactoryReturnsTableGatewayInstanceBasedOnConfiguration($adapterServiceName)
     {
-        if (class_exists(ClassMethodsHydrator::class)) {
-            $hydrator = $this->prophesize(ClassMethodsHydrator::class)->reveal();
-        } else {
-            $hydrator = $this->prophesize(ClassMethods::class)->reveal();
-        }
+        $hydrator = $this->prophesize($this->getClassMethodsHydratorClassName())->reveal();
 
         $hydrators = $this->prophesize(HydratorPluginManager::class);
         $hydrators->get('ClassMethods')->willReturn($hydrator);
@@ -205,11 +202,7 @@ class TableGatewayAbstractFactoryTest extends TestCase
      */
     public function testFactoryReturnsTableGatewayInstanceBasedOnConfigurationWithoutLaminasRest($adapterServiceName)
     {
-        if (class_exists(ClassMethodsHydrator::class)) {
-            $hydrator = $this->prophesize(ClassMethodsHydrator::class)->reveal();
-        } else {
-            $hydrator = $this->prophesize(ClassMethods::class)->reveal();
-        }
+        $hydrator = $this->prophesize($this->getClassMethodsHydratorClassName())->reveal();
 
         $hydrators = $this->prophesize(HydratorPluginManager::class);
         $hydrators->get('ClassMethods')->willReturn($hydrator);
@@ -247,13 +240,16 @@ class TableGatewayAbstractFactoryTest extends TestCase
         $this->assertSame($adapter->reveal(), $gateway->getAdapter());
         $resultSet = $gateway->getResultSetPrototype();
         $this->assertInstanceOf(HydratingResultSet::class, $resultSet);
+        $this->assertInstanceOf($this->getClassMethodsHydratorClassName(), $resultSet->getHydrator());
+        $this->assertAttributeInstanceOf(TestAsset\Bar::class, 'objectPrototype', $resultSet);
+    }
 
+    private function getClassMethodsHydratorClassName()
+    {
         if (class_exists(ClassMethodsHydrator::class)) {
-            $this->assertInstanceOf(ClassMethodsHydrator::class, $resultSet->getHydrator());
-        } else {
-            $this->assertInstanceOf(ClassMethods::class, $resultSet->getHydrator());
+            return ClassMethodsHydrator::class;
         }
 
-        $this->assertAttributeInstanceOf(TestAsset\Bar::class, 'objectPrototype', $resultSet);
+        return ClassMethods::class;
     }
 }

--- a/test/TableGatewayAbstractFactoryTest.php
+++ b/test/TableGatewayAbstractFactoryTest.php
@@ -243,6 +243,12 @@ class TableGatewayAbstractFactoryTest extends TestCase
         $this->assertAttributeInstanceOf(TestAsset\Bar::class, 'objectPrototype', $resultSet);
     }
 
+    /**
+     * Simple check whether we should use ClassMethodsHydrator from laminas-hydrator 3
+     * as ClassMethods from < 3.0.0 is deprecated and triggers an E_USER_DEPRECATED error
+     *
+     * @return string
+     */
     private function getClassMethodsHydratorClassName()
     {
         if (class_exists(ClassMethodsHydrator::class)) {

--- a/test/TableGatewayAbstractFactoryTest.php
+++ b/test/TableGatewayAbstractFactoryTest.php
@@ -16,6 +16,7 @@ use Laminas\Db\Adapter\Platform\PlatformInterface as DbPlatformInterface;
 use Laminas\Db\ResultSet\HydratingResultSet;
 use Laminas\Db\TableGateway\TableGateway;
 use Laminas\Hydrator\ClassMethods;
+use Laminas\Hydrator\ClassMethodsHydrator;
 use Laminas\Hydrator\HydratorPluginManager;
 use PHPUnit\Framework\TestCase;
 
@@ -149,7 +150,12 @@ class TableGatewayAbstractFactoryTest extends TestCase
      */
     public function testFactoryReturnsTableGatewayInstanceBasedOnConfiguration($adapterServiceName)
     {
-        $hydrator = $this->prophesize(ClassMethods::class)->reveal();
+        if (class_exists(ClassMethodsHydrator::class)) {
+            $hydrator = $this->prophesize(ClassMethodsHydrator::class)->reveal();
+        } else {
+            $hydrator = $this->prophesize(ClassMethods::class)->reveal();
+        }
+
         $hydrators = $this->prophesize(HydratorPluginManager::class);
         $hydrators->get('ClassMethods')->willReturn($hydrator);
         $this->services->get('HydratorManager')->willReturn($hydrators->reveal());
@@ -199,7 +205,12 @@ class TableGatewayAbstractFactoryTest extends TestCase
      */
     public function testFactoryReturnsTableGatewayInstanceBasedOnConfigurationWithoutLaminasRest($adapterServiceName)
     {
-        $hydrator = $this->prophesize(ClassMethods::class)->reveal();
+        if (class_exists(ClassMethodsHydrator::class)) {
+            $hydrator = $this->prophesize(ClassMethodsHydrator::class)->reveal();
+        } else {
+            $hydrator = $this->prophesize(ClassMethods::class)->reveal();
+        }
+
         $hydrators = $this->prophesize(HydratorPluginManager::class);
         $hydrators->get('ClassMethods')->willReturn($hydrator);
         $this->services->get('HydratorManager')->willReturn($hydrators->reveal());
@@ -236,7 +247,13 @@ class TableGatewayAbstractFactoryTest extends TestCase
         $this->assertSame($adapter->reveal(), $gateway->getAdapter());
         $resultSet = $gateway->getResultSetPrototype();
         $this->assertInstanceOf(HydratingResultSet::class, $resultSet);
-        $this->assertInstanceOf(ClassMethods::class, $resultSet->getHydrator());
+
+        if (class_exists(ClassMethodsHydrator::class)) {
+            $this->assertInstanceOf(ClassMethodsHydrator::class, $resultSet->getHydrator());
+        } else {
+            $this->assertInstanceOf(ClassMethods::class, $resultSet->getHydrator());
+        }
+
         $this->assertAttributeInstanceOf(TestAsset\Bar::class, 'objectPrototype', $resultSet);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Builds were failing using latest dependencies on php 7.2+, because Laminas\Hydrator 3.0.0 deprecated the ClassMethods hydrator.

This PR tries to remain backwards compatible by checking if the replacement for ClassMethods is available. This is obviously just a stopgap, as a better solution may be to release a new version that bumps the minimum php version to 7.2 and drop the backwards compatibility altogether